### PR TITLE
prepatch crates

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -507,6 +507,9 @@ class SemverRange(object):
         return "SemverRange(%s, op=%s, semver=%s, lower=%s, upper=%s)" % (repr(self._input), self._op, self._semver, self._lower, self._upper)
 
     def __str__(self):
+        # 0 semvers do not have to crash on display: maybe this is a source dependency that we could not find in index
+        if isinstance(self._input, int):
+            return str(self._input)
         return self._input
 
     def lower(self):

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1334,7 +1334,7 @@ def patch_crates(targetdir, patchdir):
       <crate>/
         <patch>.patch
     """
-    for patch in glob(os.path.join(patchdir, '*', '*.patch')):
+    for patch in glob(os.path.join(patchdir, '*', '*')):
         crateid = os.path.basename(os.path.dirname(patch))
         m = re.match(r'^([A-Za-z0-9_-]+?)(?:-([\d.]+))?$', crateid)
         if m:
@@ -1352,7 +1352,7 @@ def prepatch_crate(cratedir, patchdir):
     crateid = os.path.basename(cratedir)
     m = re.match(r'^([A-Za-z0-9_-]+?)(?:-([\d.]+))?$', crateid)
     cratename = m.group(1)
-    for patch in glob(os.path.join(patchdir, cratename, '*.patch')):
+    for patch in glob(os.path.join(patchdir, cratename, '*')):
         patch_crate(cratedir, patch)
 
 def patch_crate(cratedir, patch):
@@ -1369,6 +1369,14 @@ def patch_crate(cratedir, patch):
                 rc = p.wait()
                 if rc != 0:
                     dbg("%s: failed to apply %s (rc=%s)" % (os.path.basename(cratedir), os.path.basename(patch), rc))
+            else:
+                dbg("%s: %s does not apply (rc=%s)" % (os.path.basename(cratedir), os.path.basename(patch), rc))
+        else:
+            patchpath = os.path.abspath(patch)
+            p = subprocess.Popen([patchpath], cwd=cratedir)
+            rc = p.wait()
+            if rc == 0:
+                dbg("patching %s with patch %s" % (os.path.basename(cratedir), os.path.basename(patch)))
             else:
                 dbg("%s: %s does not apply (rc=%s)" % (os.path.basename(cratedir), os.path.basename(patch), rc))
 


### PR DESCRIPTION
3 patches to bootstrap.py to make it more universal:
- patch crate before even reading the Cargo.toml (thus allowing Cargo.toml itself to be modified)
- allow any patch (*.patch still gets played by the patch utility, everything else is run directly)
- do not crash when a semver does not match. My test case was compiling a software from a nightly, with two subsources, one for the lib, one for the binary. The binary's Cargo.toml will require the lib's crate, but won't find it in the index: the resulting SemverRange holds a 0 (int), which crashes **str**. Protecting **str** makes it more forgetful, relying on compile time to detect if the (non-index-referenced) library has indeed been compiled in the target-dir.

Specifically, those changes allowed to compile a full pijul (+ libpijul) twithout cargo.
